### PR TITLE
Require PHPUnit as developer dependancy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,19 @@
     ],
     "require": {
         "symfony/console": "^3.1",
-        "symfony/process": "^3.1",
+        "symfony/process": "^3.1"
+    },
+    "require-dev": {
         "phpunit/phpunit": "^4.8"
     },
     "autoload": {
     	"psr-4": {
-            "Zeeshan\\GitProfile\\": "src",
-    		"Tests\\": "tests"
+            "Zeeshan\\GitProfile\\": "src"
     	}
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests"
+        }
     }
 }


### PR DESCRIPTION
No PHPUnit classes are used in the library itself, thus should be included as a development dependancy.