### PR TITLE
Add signingkey support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_script:
 
 script:
   - ./vendor/bin/simple-phpunit -v
-  - ./vendor/bin/phpcs --standard=PSR2 src
 
 notifications:
     on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
   - composer install
 
 script:
-  - ./vendor/bin/phpunit
+  - ./vendor/bin/simple-phpunit -v
   - ./vendor/bin/phpcs --standard=PSR2 src
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,13 @@
         "symfony/process": "^3.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
-        "squizlabs/php_codesniffer": "2.*",
-        "kherge/box": "~2.5"
+        "kherge/box": "~2.5",
+        "symfony/phpunit-bridge": "^3.2"
     },
     "autoload": {
-    	"psr-4": {
+        "psr-4": {
             "Zeeshan\\GitProfile\\": "src"
-    	}
+        }
     },
     "autoload-dev": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,10 +3,21 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="tests/bootstrap.php">
+         bootstrap="vendor/autoload.php">
+
     <testsuites>
         <testsuite name="Main suite">
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>.</directory>
+            <exclude>
+                <directory>vendor</directory>
+                <directory>tests</directory>
+            </exclude>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/src/Commands/AddGitProfileCommand.php
+++ b/src/Commands/AddGitProfileCommand.php
@@ -2,7 +2,6 @@
 
 namespace Zeeshan\GitProfile\Commands;
 
-use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Commands/AddGitProfileCommand.php
+++ b/src/Commands/AddGitProfileCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class AddGitProfileCommand extends BaseCommand
 {
-
     /**
      * @var InputInterface
      */
@@ -56,59 +55,13 @@ class AddGitProfileCommand extends BaseCommand
 
         $output->writeln('');
         $username = $this->askQuestion("[+] Enter Name: ", 'Name is required.');
-        $useremail = $this->askQuestion("[+] Enter Email: ", 'Email is required.');
+        $email = $this->askQuestion("[+] Enter Email: ", 'Email is required.');
+        $signingkey = $this->askQuestion("[+] Enter Signingkey: ", 'Signingkey is optional.', false);
 
         $output->writeln('');
 
-        if ($this->saveProfile($profileTitle, $username, $useremail)) {
+        if ($this->saveProfile($profileTitle, $username, $email, $signingkey)) {
             $style->success('Profile "' . $profileTitle . '" saved successfuly');
         }
-    }
-
-    /**
-     * On CLI ask quesion to user.
-     *
-     * @param  string $question
-     * @param  string $message
-     *
-     * @return mixed
-     */
-    public function askQuestion($question, $message)
-    {
-        $helper = $this->getHelper('question');
-        $output = $this->output;
-
-        $question = new Question($question);
-        $style = new SymfonyStyle($this->input, $this->output);
-
-        $question->setValidator(function ($value) use ($output, $message, $style) {
-            if (empty($value)) {
-                $style->error($message);
-                exit(1);
-            }
-
-            return $value;
-        });
-
-        return $helper->ask($this->input, $this->output, $question);
-    }
-
-    /**
-     * Save git profile
-     *
-     * @param  string $profileTitle
-     * @param  string $username
-     * @param  string $useremail
-     *
-     * @return boolean
-     */
-    public function saveProfile($profileTitle, $username, $useremail)
-    {
-        $mustRun = true;
-
-        $this->runCommand(sprintf('git config --global profile."%s".name "%s"', $profileTitle, $username), $mustRun);
-        $this->runCommand(sprintf('git config --global profile."%s".email "%s"', $profileTitle, $useremail), $mustRun);
-
-        return true;
     }
 }

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -4,6 +4,8 @@ namespace Zeeshan\GitProfile\Commands;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * @package   Git Profile
@@ -96,7 +98,7 @@ class BaseCommand extends Command
      *
      * @param  string $question
      * @param  string $message
-     * @param  string $required
+     * @param  bool $required
      *
      * @return mixed
      */

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -90,4 +90,59 @@ class BaseCommand extends Command
 
         return false;
     }
+
+    /**
+     * On CLI ask quesion to user.
+     *
+     * @param  string $question
+     * @param  string $message
+     * @param  string $required
+     *
+     * @return mixed
+     */
+    public function askQuestion($question, $message, $required = true)
+    {
+        $helper = $this->getHelper('question');
+        $output = $this->output;
+
+        $question = new Question($question);
+        $style = new SymfonyStyle($this->input, $this->output);
+
+        if ($required) {
+            $question->setValidator(function ($value) use ($output, $message, $style) {
+                if (empty($value)) {
+                    $style->error($message);
+                    exit(1);
+                }
+
+                return $value;
+            });
+        }
+
+        return $helper->ask($this->input, $this->output, $question);
+    }
+
+    /**
+     * Save git profile
+     *
+     * @param  string $profileTitle
+     * @param  string $username
+     * @param  string $email
+     * @param  string $signingkey
+     *
+     * @return boolean
+     */
+    public function saveProfile($profileTitle, $username, $email, $signingkey = '')
+    {
+        $mustRun = true;
+
+        $this->runCommand(sprintf('git config --global profile."%s".name "%s"', $profileTitle, $username), $mustRun);
+        $this->runCommand(sprintf('git config --global profile."%s".email "%s"', $profileTitle, $email), $mustRun);
+
+        if ($signingkey) {
+            $this->runCommand(sprintf('git config --global profile."%s".signingkey "%s"', $profileTitle, $signingkey), $mustRun);
+        }
+
+        return true;
+    }
 }

--- a/src/Commands/CurrentGitProfileCommand.php
+++ b/src/Commands/CurrentGitProfileCommand.php
@@ -46,11 +46,13 @@ class CurrentGitProfileCommand extends BaseCommand
         if (!empty($currentProfile) && $this->doesProfileExists($currentProfile)) {
             $email = $this->runCommand(sprintf('git config --global profile.%s.email', $currentProfile));
             $name = $this->runCommand(sprintf('git config --global profile.%s.name', $currentProfile));
+            $signingkey = $this->runCommand(sprintf('git config --global profile.%s.signingkey', $currentProfile));
 
             $output->writeln('');
             $output->writeln('[+] Current Profile: ' . $currentProfile);
             $output->writeln('[+] Name: ' . $name);
             $output->writeln('[+] Email: ' . $email);
+            $output->writeln('[+] Signingkey: ' . $signingkey);
             exit();
         }
 
@@ -58,5 +60,6 @@ class CurrentGitProfileCommand extends BaseCommand
         $output->writeln('[+] Profile is not set. Standard settings are used.');
         $output->writeln(sprintf('[+] Name: %s', $this->runCommand(sprintf('git config user.name'))));
         $output->writeln(sprintf('[+] Email: %s', $this->runCommand(sprintf('git config user.email'))));
+        $output->writeln(sprintf('[+] Signingkey: %s', $this->runCommand(sprintf('git config user.signingkey'))));
     }
 }

--- a/src/Commands/ShowGitProfileCommand.php
+++ b/src/Commands/ShowGitProfileCommand.php
@@ -47,6 +47,7 @@ class ShowGitProfileCommand extends BaseCommand
             $output->writeln('');
             $output->writeln('[+] Name: ' . $profileInfo['name']);
             $output->writeln('[+] Email: ' . $profileInfo['email']);
+            $output->writeln('[+] Signingkey: ' . $profileInfo['signingkey']);
             exit();
         };
 
@@ -72,6 +73,11 @@ class ShowGitProfileCommand extends BaseCommand
 
         $profileInfo['email'] = $this->runCommand(
             sprintf('git config --global profile."%s".email', $profileTitle),
+            $mustRun
+        );
+
+        $profileInfo['signingkey'] = $this->runCommand(
+            sprintf('git config --global profile."%s".signingkey', $profileTitle),
             $mustRun
         );
 

--- a/src/Commands/UpdateGitProfileCommand.php
+++ b/src/Commands/UpdateGitProfileCommand.php
@@ -2,7 +2,6 @@
 
 namespace Zeeshan\GitProfile\Commands;
 
-use Symfony\Component\Console\Question\Question;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Commands/UpdateGitProfileCommand.php
+++ b/src/Commands/UpdateGitProfileCommand.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class UpdateGitProfileCommand extends BaseCommand
 {
-
     /**
      * @var InputInterface
      */
@@ -61,58 +60,13 @@ class UpdateGitProfileCommand extends BaseCommand
 
         $output->writeln('');
         $username = $this->askQuestion("[+] Enter Name: ", 'Name is required.');
-        $useremail = $this->askQuestion("[+] Enter Email: ", 'Email is required.');
+        $email = $this->askQuestion("[+] Enter Email: ", 'Email is required.');
+        $signingkey = $this->askQuestion("[+] Enter Signingkey: ", 'Signingkey is optional.', false);
+
         $output->writeln('');
 
-        if ($this->updateProfile($profileTitle, $username, $useremail)) {
+        if ($this->saveProfile($profileTitle, $username, $email, $signingkey)) {
             $style->success('Profile "' . $profileTitle . '" updated successfuly');
         }
-    }
-
-    /**
-     * On CLI ask quesion to user.
-     *
-     * @param  string $question
-     * @param  string $message
-     *
-     * @return mixed
-     */
-    public function askQuestion($question, $message)
-    {
-        $helper = $this->getHelper('question');
-        $output = $this->output;
-
-        $question = new Question($question);
-        $style = new SymfonyStyle($this->input, $this->output);
-
-        $question->setValidator(function ($value) use ($output, $message, $style) {
-
-            if (empty($value)) {
-                $style->error($message);
-                exit(1);
-            }
-
-            return $value;
-        });
-
-        return $helper->ask($this->input, $this->output, $question);
-    }
-
-    /**
-     * Update git profile
-     *
-     * @param  string $profileTitle
-     * @param  string $username
-     * @param  string $useremail
-     *
-     * @return boolean
-     */
-    public function updateProfile($profileTitle, $username, $useremail)
-    {
-        $mustRun = true;
-        $this->runCommand(sprintf('git config --global profile."%s".name "%s"', $profileTitle, $username), $mustRun);
-        $this->runCommand(sprintf('git config --global profile."%s".email "%s"', $profileTitle, $useremail), $mustRun);
-
-        return true;
     }
 }

--- a/src/Commands/UseGitProfileCommand.php
+++ b/src/Commands/UseGitProfileCommand.php
@@ -47,12 +47,14 @@ class UseGitProfileCommand extends BaseCommand
             exit(1);
         }
 
-        $email = $this->runCommand(sprintf('git config --global profile.%s.email', $profileTitle));
         $name  = $this->runCommand(sprintf('git config --global profile.%s.name', $profileTitle));
+        $email  = $this->runCommand(sprintf('git config --global profile.%s.email', $profileTitle));
+        $signingkey = $this->runCommand(sprintf('git config --global profile.%s.signingkey', $profileTitle));
 
         if ($input->getOption('global')) {
             $this->runCommand(sprintf('git config --global user.name "%s"', $name), $mustRun);
             $this->runCommand(sprintf('git config --global user.email "%s"', $email), $mustRun);
+            $this->runCommand(sprintf('git config --global user.signingkey "%s"', $signingkey), $mustRun);
 
             $this->switchProfile($profileTitle, 'global');
 
@@ -63,6 +65,7 @@ class UseGitProfileCommand extends BaseCommand
 
         $this->runCommand(sprintf('git config user.name "%s"', $name), $mustRun);
         $this->runCommand(sprintf('git config user.email "%s"', $email), $mustRun);
+        $this->runCommand(sprintf('git config user.signingkey "%s"', $signingkey), $mustRun);
 
         $this->switchProfile($profileTitle);
 

--- a/tests/Commands/AddGitProfileCommandTest.php
+++ b/tests/Commands/AddGitProfileCommandTest.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace Tests\Commands;
 
@@ -16,7 +16,7 @@ class AddGitProfileCommandTest extends \PHPUnit_Framework_TestCase
 
     public function testSaveProfileShouldSaveGitProfile()
     {
-        $result = $this->command->saveProfile('Personal', 'Zeeshan Ahmed', 'ziishaned@gmail.com');
+        $result = $this->command->saveProfile('Personal', 'Zeeshan Ahmed', 'ziishaned@gmail.com', 'B7789A12');
         $this->assertTrue($result);
     }
 }

--- a/tests/Commands/RemoveGitProfileCommandTest.php
+++ b/tests/Commands/RemoveGitProfileCommandTest.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace Tests\Commands;
 
@@ -13,7 +13,7 @@ class RemoveGitProfileCommandTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $this->command = new RemoveGitProfileCommand();
-        (new AddGitProfileCommand)->saveProfile('Personal', 'Zeeshan Ahmed', 'ziishaned@gmail.com');
+        (new AddGitProfileCommand)->saveProfile('Personal', 'Zeeshan Ahmed', 'ziishaned@gmail.com', 'B7789A12');
     }
 
     public function testRemoveProfileShouldRemoveGitProfile()

--- a/tests/Commands/RemoveGitProfileCommandTest.php
+++ b/tests/Commands/RemoveGitProfileCommandTest.php
@@ -30,7 +30,6 @@ class RemoveGitProfileCommandTest extends \PHPUnit_Framework_TestCase
 
     public function testDoesProfileExistsMustReturnTrueIfProfileExists()
     {
-        $this->setUp();
         $result = $this->command->doesProfileExists('Personal');
         $this->assertTrue($result);
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require_once __DIR__.'/../vendor/autoload.php';


### PR DESCRIPTION
See https://git-scm.com/book/tr/v2/Git-Tools-Signing-Your-Work

Also:

 - Move `askQuestion` & `saveProfile` to BaseCommand to avoid duplication
 - Use simple-phpunit instead of phpunit (see http://symfony.com/doc/current/components/phpunit_bridge.html). _Basically it display deprecated message from Symfony but also provide PHPUnit support for all version using the lowest available_

Also I think phpcs is bit outdated and it should be better to use php-cs-fixer instead.
I might be able to push an other PR with that change after that one got merged if you want.