### PR TITLE
Do not write empty signingkey

### DIFF
--- a/src/Commands/UseGitProfileCommand.php
+++ b/src/Commands/UseGitProfileCommand.php
@@ -49,7 +49,9 @@ class UseGitProfileCommand extends BaseCommand
         if ($input->getOption('global')) {
             $this->runCommand(sprintf('git config --global user.name "%s"', $name), $mustRun);
             $this->runCommand(sprintf('git config --global user.email "%s"', $email), $mustRun);
-            $this->runCommand(sprintf('git config --global user.signingkey "%s"', $signingkey), $mustRun);
+            if ($signingkey) {
+                $this->runCommand(sprintf('git config --global user.signingkey "%s"', $signingkey), $mustRun);
+            }
 
             $this->switchProfile($profileTitle, 'global');
 
@@ -61,7 +63,9 @@ class UseGitProfileCommand extends BaseCommand
 
         $this->runCommand(sprintf('git config user.name "%s"', $name), $mustRun);
         $this->runCommand(sprintf('git config user.email "%s"', $email), $mustRun);
-        $this->runCommand(sprintf('git config user.signingkey "%s"', $signingkey), $mustRun);
+        if ($signingkey) {
+            $this->runCommand(sprintf('git config user.signingkey "%s"', $signingkey), $mustRun);
+        }
 
         $this->switchProfile($profileTitle);
 


### PR DESCRIPTION
If no signingkey are provided, we don't need to write it down.